### PR TITLE
Ignore changes on restore_to_point_in_time dynamic block

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -130,7 +130,10 @@ resource "aws_rds_cluster" "this" {
   }
 
   lifecycle {
-    ignore_changes = [snapshot_identifier]
+    ignore_changes = [
+      snapshot_identifier,
+      restore_to_point_in_time,
+    ]
   }
 }
 


### PR DESCRIPTION
Relatert issue: https://github.com/hashicorp/terraform-provider-aws/issues/32888

Legger til en `ignore_changes` på `dynamic`-blokken for å klone aurora-clusters. Uten den får vi ikke fjernet kloningen uten å rulle ut hele clusteret på nytt 🙃 Se diff med og uten blokk under.

Modul på `0.4.0` : `Plan: 7 to add, 1 to change, 2 to destroy.`
<details>
<summary>Terraform-endringer: </summary>

```
  # module.trafficcontrol-reiserad-backend.module.database[0].aws_rds_cluster.this must be replaced
+/- resource "aws_rds_cluster" "this" {
      ~ allocated_storage                   = 1 -> (known after apply)
      ~ arn                                 = "arn:aws:rds:eu-west-1:214510272858:cluster:reiserad-backend" -> (known after apply)
      - backtrack_window                    = 0 -> null
      + cluster_identifier_prefix           = (known after apply)
      ~ cluster_members                     = [
          - "reiserad-backend-020240315123713708100000002",
        ] -> (known after apply)
      ~ cluster_resource_id                 = "cluster-NNHNT3U4OFPN3VQ6PYYPOPNQNI" -> (known after apply)
      ~ db_cluster_parameter_group_name     = "default.aurora-postgresql13" -> (known after apply)
      + db_system_id                        = (known after apply)
      - deletion_protection                 = false -> null
      - enabled_cloudwatch_logs_exports     = [] -> null
      ~ endpoint                            = "reiserad-backend.cluster-cgqfsdfmcawp.eu-west-1.rds.amazonaws.com" -> (known after apply)
      ~ engine_version_actual               = "13.13" -> (known after apply)
      ~ hosted_zone_id                      = "Z29XKXDKYMONMX" -> (known after apply)
      - iam_database_authentication_enabled = false -> null
      ~ iam_roles                           = [] -> (known after apply)
      ~ id                                  = "reiserad-backend" -> (known after apply)
      - iops                                = 0 -> null
      ~ kms_key_id                          = "arn:aws:kms:eu-west-1:214510272858:key/20163500-c060-4353-ad59-3e1b10185322" -> (known after apply)
      ~ master_user_secret                  = [] -> (known after apply)
      + master_user_secret_kms_key_id       = (known after apply)
      ~ network_type                        = "IPV4" -> (known after apply)
      ~ port                                = 5432 -> (known after apply)
      ~ reader_endpoint                     = "reiserad-backend.cluster-ro-cgqfsdfmcawp.eu-west-1.rds.amazonaws.com" -> (known after apply)
      + storage_type                        = (known after apply)
      - tags                                = {} -> null
        # (23 unchanged attributes hidden)

      - restore_to_point_in_time { # forces replacement
          - restore_type               = "copy-on-write" -> null # forces replacement
          - source_cluster_identifier  = "arn:aws:rds:eu-west-1:214510272858:cluster:tmp-reiserad-backend-cluster" -> null # forces replacement
          - use_latest_restorable_time = true -> null # forces replacement
        }
    }

  # module.trafficcontrol-reiserad-backend.module.database[0].aws_rds_cluster_instance.this[0] must be replaced
+/- resource "aws_rds_cluster_instance" "this" {
      ~ arn                                   = "arn:aws:rds:eu-west-1:214510272858:db:reiserad-backend-020240315123713708100000002" -> (known after apply)
      ~ availability_zone                     = "eu-west-1c" -> (known after apply)
      ~ ca_cert_identifier                    = "rds-ca-rsa2048-g1" -> (known after apply)
      ~ cluster_identifier                    = "reiserad-backend" # forces replacement -> (known after apply) # forces replacement
      ~ db_parameter_group_name               = "default.aurora-postgresql13" -> (known after apply)
      ~ db_subnet_group_name                  = "reiserad-backend20240315123417602800000001" -> (known after apply)
      ~ dbi_resource_id                       = "db-IN5SERHR2UWR4AH62JLA462TJE" -> (known after apply)
      ~ endpoint                              = "reiserad-backend-020240315123713708100000002.cgqfsdfmcawp.eu-west-1.rds.amazonaws.com" -> (known after apply)
      ~ engine_version_actual                 = "13.13" -> (known after apply)
      ~ id                                    = "reiserad-backend-020240315123713708100000002" -> (known after apply)
      ~ identifier                            = "reiserad-backend-020240315123713708100000002" -> (known after apply)
      ~ kms_key_id                            = "arn:aws:kms:eu-west-1:214510272858:key/20163500-c060-4353-ad59-3e1b10185322" -> (known after apply)
      + monitoring_role_arn                   = (known after apply)
      ~ network_type                          = "IPV4" -> (known after apply)
      ~ performance_insights_kms_key_id       = "arn:aws:kms:eu-west-1:214510272858:key/20163500-c060-4353-ad59-3e1b10185322" -> (known after apply)
      ~ performance_insights_retention_period = 7 -> (known after apply)
      ~ port                                  = 5432 -> (known after apply)
      ~ preferred_backup_window               = "03:00-04:00" -> (known after apply)
      ~ preferred_maintenance_window          = "sat:02:44-sat:03:14" -> (known after apply)
      ~ publicly_accessible                   = false -> (known after apply)
      ~ storage_encrypted                     = true -> (known after apply)
      - tags                                  = {} -> null
      ~ writer                                = true -> (known after apply)
        # (11 unchanged attributes hidden)
    }

```
</details>

Modul på denne branchen :  `Plan: 5 to add, 1 to change, 0 to destroy.`