### PR TITLE
Add deletion protection variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -96,13 +96,16 @@ resource "aws_rds_cluster" "this" {
   vpc_security_group_ids = [aws_security_group.this.id]
 
   # Database Setup
-  engine            = "aurora-${var.engine}"
-  engine_version    = var.engine_version
+  engine         = "aurora-${var.engine}"
+  engine_version = var.engine_version
   # The application name might contain non-alphanumeric, which is not allowed for database names.
   database_name     = var.replicate_from_database != null ? null : (var.database_name != null ? var.database_name : replace(var.application_name, "/[^a-zA-Z\\d]/", ""))
   storage_encrypted = true
   master_username   = var.replicate_from_database != null ? null : (var.master_username != null ? var.master_username : random_pet.master_username[0].id)
   master_password   = var.replicate_from_database != null ? null : (var.master_password != null ? var.master_password : random_password.master_password[0].result)
+
+  # Deletion Protection
+  deletion_protection = var.deletion_protection
 
   # Backup & Maintenance
   apply_immediately            = var.apply_immediately
@@ -115,7 +118,7 @@ resource "aws_rds_cluster" "this" {
   # Replicate with zero downtime
   replication_source_identifier = var.replicate_from_database
   # For restoring from snapshot
-  snapshot_identifier           = var.restore_from_snapshot
+  snapshot_identifier = var.restore_from_snapshot
 
   tags = var.tags
 

--- a/variables.tf
+++ b/variables.tf
@@ -178,3 +178,9 @@ variable "ca_cert_identifier" {
   type        = string
   default     = "rds-ca-rsa2048-g1"
 }
+
+variable "deletion_protection" {
+  description = "If the DB cluster should have deletion protection enabled"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
**Background**
We in team-reise discovered that both our AuroraDB had the "Deletion Protection" disabled. It seems like this applies to all of the AuroraDB using this dependency. It defaults to false when not defined. 

**Solution**
We have set it to true, well aware of that it will be a breaking change? We believe that this is a safer approach and that it is better to set the value specifically to false if needed. We have so far tested it locally in one of the applications and will continue in the test-env for the application using this dependency.